### PR TITLE
Fix permission elevation

### DIFF
--- a/bright
+++ b/bright
@@ -3,7 +3,7 @@ echo $@
 exit 1
 }
 
-[ $EUID -ne 0 ] && {
+[ "$(id -u)" != "0" ] && {
 sudo $0 $@
 exit $?
 }


### PR DESCRIPTION
On ubuntu (and possibly more operating systems) the permission elevation did not work due to error on -ne flag (likely leading back to $EUID)
